### PR TITLE
Implement node renaming via dataframe concatenation

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -170,6 +170,29 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         )
         return self.__constructor__(new_modin_frame)
 
+    def drop(self, index=None, columns=None):
+        """Remove row data for target index and columns.
+
+        Args:
+            index: Target index to drop.
+            columns: Target columns to drop.
+
+        Returns:
+            A new QueryCompiler.
+        """
+        assert index == None, "Only column drop is supported"
+        res_columns = []
+        if columns is not None:
+            for c in self.columns:
+                if not c in columns:
+                    res_columns.append(c)
+
+        return self.__constructor__(
+            self._modin_frame.mask(row_indices=index, col_indices=res_columns)
+        )
+
+
+
     def free(self):
         return
 
@@ -202,7 +225,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     cumsum = DFAlgNotSupported("cumsum")
     describe = DFAlgNotSupported("describe")
     diff = DFAlgNotSupported("diff")
-    drop = DFAlgNotSupported("drop")
     dropna = DFAlgNotSupported("dropna")
     eq = DFAlgNotSupported("eq")
     eval = DFAlgNotSupported("eval")

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -126,7 +126,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self._modin_frame.columns
 
     def _set_columns(self, columns):
-        self._modin_frame.columns = columns
+        self._modin_frame = self._modin_frame._set_columns(columns)
 
     def fillna(
         self,

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -116,38 +116,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             new_qc = new_qc.squeeze()
         return new_qc
 
-    def concat(self, axis, other, **kwargs):
-        """Concatenates two objects together.
-
-        Args:
-            axis: The axis index object to join (0 for columns, 1 for index).
-            other: The other_index to concat with.
-
-        Returns:
-            Concatenated objects.
-        """
-        if not isinstance(other, list):
-            other = [other]
-        assert all(
-            isinstance(o, type(self)) for o in other
-        ), "Different Manager objects are being used. This is not allowed"
-
-        sort = kwargs.get("sort", None)
-        if sort is None:
-            sort = False
-        join = kwargs.get("join", "outer")
-        ignore_index = kwargs.get("ignore_index", False)
-        other_modin_frame = [o._modin_frame for o in other]
-        new_modin_frame = self._modin_frame._concat(axis, other_modin_frame, join, sort)
-        assert (
-            ignore_index == False
-        ), "Option ignore_index is not supported in omnisci backend"
-        # if ignore_index:
-        #     new_modin_frame.index = pandas.RangeIndex(
-        #         len(self.index) + sum(len(o.index) for o in other)
-        #     )
-        return self.__constructor__(new_modin_frame)
-
     def _get_index(self):
         return self._modin_frame.index
 
@@ -196,9 +164,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         join = kwargs.get("join", "outer")
         ignore_index = kwargs.get("ignore_index", False)
         other_modin_frames = [o._modin_frame for o in other]
-
-        if axis == 1:
-            raise NotImplementedError("concat for axis = 1 is not supported yet")
 
         new_modin_frame = self._modin_frame._concat(
             axis, other_modin_frames, join=join, sort=sort, ignore_index=ignore_index

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -116,6 +116,38 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             new_qc = new_qc.squeeze()
         return new_qc
 
+    def concat(self, axis, other, **kwargs):
+        """Concatenates two objects together.
+
+        Args:
+            axis: The axis index object to join (0 for columns, 1 for index).
+            other: The other_index to concat with.
+
+        Returns:
+            Concatenated objects.
+        """
+        if not isinstance(other, list):
+            other = [other]
+        assert all(
+            isinstance(o, type(self)) for o in other
+        ), "Different Manager objects are being used. This is not allowed"
+
+        sort = kwargs.get("sort", None)
+        if sort is None:
+            sort = False
+        join = kwargs.get("join", "outer")
+        ignore_index = kwargs.get("ignore_index", False)
+        other_modin_frame = [o._modin_frame for o in other]
+        new_modin_frame = self._modin_frame._concat(axis, other_modin_frame, join, sort)
+        assert (
+            ignore_index == False
+        ), "Option ignore_index is not supported in omnisci backend"
+        # if ignore_index:
+        #     new_modin_frame.index = pandas.RangeIndex(
+        #         len(self.index) + sum(len(o.index) for o in other)
+        #     )
+        return self.__constructor__(new_modin_frame)
+
     def _get_index(self):
         return self._modin_frame.index
 

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -181,14 +181,8 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             A new QueryCompiler.
         """
         assert index == None, "Only column drop is supported"
-        res_columns = []
-        if columns is not None:
-            for c in self.columns:
-                if not c in columns:
-                    res_columns.append(c)
-
         return self.__constructor__(
-            self._modin_frame.mask(row_indices=index, col_indices=res_columns)
+            self._modin_frame.mask(row_indices=index, col_indices=self.columns.drop(columns))
         )
 
 

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -264,64 +264,100 @@ class OmnisciOnRayFrame(BasePandasFrame):
     def _concat(
         self, axis, other_modin_frames, join="outer", sort=False, ignore_index=False
     ):
-        assert axis == 0, "unsupported concat on axis = 1"
-
-        # determine output columns
-        new_columns = OrderedDict()
-        for col in self.columns:
-            new_columns[col] = 1
-        for frame in other_modin_frames:
-            if join == "inner":
-                for col in list(new_columns):
-                    if col not in frame.columns:
-                        del new_columns[col]
-            else:
-                for col in frame.columns:
-                    if col not in new_columns:
-                        new_columns[col] = 1
-        new_columns = list(new_columns.keys())
-
-        if sort:
-            new_columns = sorted(new_columns)
-
-        # determine how many index components are going into
-        # the resulting table
-        if not ignore_index:
-            index_width = self._index_width()
+        if axis == 0:
+            # determine output columns
+            new_columns = OrderedDict()
+            for col in self.columns:
+                new_columns[col] = 1
             for frame in other_modin_frames:
-                index_width = min(index_width, frame._index_width())
+                if join == "inner":
+                    for col in list(new_columns):
+                        if col not in frame.columns:
+                            del new_columns[col]
+                else:
+                    for col in frame.columns:
+                        if col not in new_columns:
+                            new_columns[col] = 1
+            new_columns = list(new_columns.keys())
 
-        # build projections to align all frames
-        aligned_frames = []
-        for frame in [self] + other_modin_frames:
-            aligned_index = None
-            exprs = {}
+            if sort:
+                new_columns = sorted(new_columns)
+
+            # determine how many index components are going into
+            # the resulting table
             if not ignore_index:
-                if frame._index_cols:
-                    aligned_index = frame._index_cols[0 : index_width + 1]
-                    for i in range(0, index_width):
-                        col = frame._index_cols[i]
-                        exprs[col] = frame.ref(col)
-                else:
-                    assert index_width == 1, "unexpected index width"
-                    aligned_index = ["__index__"]
-                    exprs["__index__"] = frame.ref("__rowid__")
-            for col in new_columns:
-                if col in frame._table_cols:
-                    exprs[col] = frame.ref(col)
-                else:
-                    exprs[col] = LiteralExpr(None)
-            aligned_frame_op = TransformNode(frame, exprs, False)
-            aligned_frames.append(
-                self.__constructor__(
-                    columns=new_columns, op=aligned_frame_op, index_cols=aligned_index
+                index_width = self._index_width()
+                for frame in other_modin_frames:
+                    index_width = min(index_width, frame._index_width())
+
+            # build projections to align all frames
+            aligned_frames = []
+            for frame in [self] + other_modin_frames:
+                aligned_index = None
+                exprs = {}
+                if not ignore_index:
+                    if frame._index_cols:
+                        aligned_index = frame._index_cols[0 : index_width + 1]
+                        for i in range(0, index_width):
+                            col = frame._index_cols[i]
+                            exprs[col] = InputRefExpr(frame._table_cols.index(col))
+                    else:
+                        assert index_width == 1, "unexpected index width"
+                        aligned_index = ["__index__"]
+                        exprs["__index__"] = InputRefExpr(len(frame._table_cols))
+                for col in new_columns:
+                    if col in frame._table_cols:
+                        exprs[col] = InputRefExpr(frame._table_cols.index(col))
+                    else:
+                        exprs[col] = LiteralExpr(None)
+                aligned_frame_op = TransformNode(frame, exprs, False)
+                aligned_frames.append(
+                    self.__constructor__(
+                        columns=new_columns,
+                        op=aligned_frame_op,
+                        index_cols=aligned_index,
+                    )
+                )
+
+            new_op = UnionNode(aligned_frames)
+            return self.__constructor__(
+                columns=new_columns,
+                op=new_op,
+                index_cols=aligned_frames[0]._index_cols,
+            )
+        elif axis == 1:
+            assert (
+                join == "outer"
+                and not sort
+                and len(other_modin_frames) == 1
+                and len(other_modin_frames[0].columns) == 1
+                and other_modin_frames[0]._op.input[0] == self
+            ), "Only appending one column from the same dataframe is supported"
+
+            exprs = {}
+            for c in self.columns:
+                exprs[c] = InputRefExpr(self._table_cols.index(c))
+
+            # as we don't know column name here, we need to come up with some unique name here
+            # column name is set in dataframe.__setitem__
+            exprs["__appended_column__"] = InputRefExpr(
+                other_modin_frames[0]._table_cols.index(
+                    other_modin_frames[0].columns[0]
                 )
             )
 
-        new_op = UnionNode(aligned_frames)
-        return self.__constructor__(
-            columns=new_columns, op=new_op, index_cols=aligned_frames[0]._index_cols,
-        )
+            new_op = TransformNode(self, exprs)
+
+            new_columns = [*self.columns, "__appended_column__"]
+            new_frame = self.__constructor__(
+                columns=Index.__new__(
+                    Index, data=new_columns, dtype=self.columns.dtype
+                ),
+                op=new_op,
+                index_cols=self._index_cols,
+            )
+
+            return new_frame
 
     def _execute(self):
         if isinstance(self._op, FrameNode):
@@ -356,53 +392,6 @@ class OmnisciOnRayFrame(BasePandasFrame):
 
     def _get_columns(self):
         return super(OmnisciOnRayFrame, self)._get_columns()
-
-    def _concat(self, axis, others, how, sort):
-        """Concatenate this dataframe with one or more others.
-
-        Args:
-            axis: The axis to concatenate over.
-            others: The list of dataframes to concatenate with.
-            how: The type of join to use for the axis.
-            sort: Whether or not to sort the result.
-
-        Returns:
-            A new dataframe.
-        """
-        if how != "outer":
-            raise NotImplementedError("_concat doesn't support joins yes")
-
-        if sort:
-            raise NotImplementedError("_concat doesn't support sort yet")
-
-        assert (
-            axis == 1
-            and all(o.index.equals(self.index) for o in others)
-            and all(o._row_lengths == self._row_lengths for o in others)
-            and len(others) == 1
-            and len(others[0].columns) == 1
-        ), "Only appending one column from the same dataframe is supported"
-
-        exprs = {}
-        for c in self.columns:
-            exprs[c] = InputRefExpr(self._table_cols.index(c))
-
-        # as we don't know column name here, we need to come up with some unique name here
-        # column name is set in dataframe.__setitem__
-        exprs["__appended_column__"] = InputRefExpr(
-            others[0]._table_cols.index(others[0].columns[0])
-        )
-
-        new_op = TransformNode(self, exprs)
-
-        new_columns = [*self.columns, "__appended_column__"]
-        new_frame = self.__constructor__(
-            columns=Index.__new__(Index, data=new_columns, dtype=self.columns.dtype),
-            op=new_op,
-            index_cols=self._index_cols,
-        )
-
-        return new_frame
 
     columns = property(_get_columns, _set_columns)
     index = property(_get_index, _set_index)

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -343,7 +343,7 @@ class OmnisciOnRayFrame(BasePandasFrame):
 
             # as we don't know column name here, we need to come up with some unique name here
             # column name is set in dataframe.__setitem__
-            exprs["__appended_column__"] = other_modin_frames[0].ref(
+            exprs["__appended_column__"] = self.ref(
                 other_modin_frames[0].columns[0]
             )
 
@@ -381,8 +381,7 @@ class OmnisciOnRayFrame(BasePandasFrame):
 
     def _set_columns(self, new_columns):
         exprs = {new: self.ref(old) for old, new in zip(self.columns, new_columns)}
-
-        self._op = TransformNode(self, exprs)
+        # self.op = TransformNode(self, exprs)
         self._columns_cache = new_columns
         if self._index_cols is not None:
             self._table_cols = self._index_cols + new_columns.tolist()

--- a/modin/experimental/engines/omnisci_on_ray/frame/partition.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/partition.py
@@ -48,8 +48,4 @@ class OmnisciOnRayFramePartition(BaseFramePartition):
             length=len(obj.index),
             width=len(obj.columns),
         )
-
-    def add_to_apply_calls(self, func, **kwargs):
-        return OmnisciOnRayFramePartition(
-            self.data.copy(), call_queue=self.call_queue + [(func, kwargs)]
-        )
+        

--- a/modin/experimental/engines/omnisci_on_ray/frame/partition.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/partition.py
@@ -48,3 +48,8 @@ class OmnisciOnRayFramePartition(BaseFramePartition):
             length=len(obj.index),
             width=len(obj.columns),
         )
+
+    def add_to_apply_calls(self, func, **kwargs):
+        return OmnisciOnRayFramePartition(
+            self.data.copy(), call_queue=self.call_queue + [(func, kwargs)]
+        )

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -133,3 +133,19 @@ class TestMerge:
             return df1.merge(df2, on=on, how=how)
 
         run_and_compare(merge, data=self.data, data2=self.data2, on=on, how=how)
+
+
+def test_concat_with_same_df():
+    data = [[1, 11, 101], [1, 21, 201], [2, 12, 102], [2, 22, 202], [2, 32, 302]]
+    cols = ["a", "b", "c"]
+    pandas_df = pd.DataFrame(
+        data,
+        columns=cols
+    )
+    modin_df = pd.DataFrame(
+        data,
+        columns=cols
+    )
+    pandas_df["d"] = pandas_df["a"]
+    modin_df["d"] = modin_df["a"]
+    df_equals(pandas_df, modin_df)

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -135,17 +135,29 @@ class TestMerge:
         run_and_compare(merge, data=self.data, data2=self.data2, on=on, how=how)
 
 
+test_data = {
+    "a": [1, 11, 101],
+    "b": [2.3, 12.1, 102.3],
+    "c": ["str1", "oas", "steqwe"],
+}
+
+
 def test_concat_with_same_df():
     data = [[1, 11, 101], [1, 21, 201], [2, 12, 102], [2, 22, 202], [2, 32, 302]]
     cols = ["a", "b", "c"]
-    pandas_df = pd.DataFrame(
-        data,
-        columns=cols
-    )
-    modin_df = pd.DataFrame(
-        data,
-        columns=cols
-    )
+    pandas_df = pd.DataFrame(data, columns=cols)
+    modin_df = pd.DataFrame(data, columns=cols)
     pandas_df["d"] = pandas_df["a"]
     modin_df["d"] = modin_df["a"]
+    df_equals(pandas_df, modin_df)
+
+
+def test_drop():
+    data = [[1, 11, 101], [1, 21, 201], [2, 12, 102], [2, 22, 202], [2, 32, 302]]
+    cols = ["a", "b", "c"]
+    pandas_df = pd.DataFrame(data, columns=cols)
+    modin_df = pd.DataFrame(data, columns=cols)
+
+    pandas_df = pandas_df.drop(columns="a")
+    modin_df = modin_df.drop(columns="a")
     df_equals(pandas_df, modin_df)

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -41,6 +41,14 @@ class TestMasks:
 
         run_and_compare(projection, data=self.data, cols=cols)
 
+    def test_drop(self):
+        pandas_df = pd.DataFrame(self.data)
+        modin_df = pd.DataFrame(self.data)
+
+        pandas_df = pandas_df.drop(columns="a")
+        modin_df = modin_df.drop(columns="a")
+        df_equals(pandas_df, modin_df)
+
 
 class TestFillna:
     data = {"a": [1, 1, None], "b": [None, None, 2], "c": [3, None, None]}
@@ -85,6 +93,13 @@ class TestConcat:
             sort=sort,
             ignore_index=ignore_index,
         )
+
+    def test_concat_with_same_df(self):
+        pandas_df = pd.DataFrame(self.data)
+        modin_df = pd.DataFrame(self.data)
+        pandas_df["d"] = pandas_df["a"]
+        modin_df["d"] = modin_df["a"]
+        df_equals(pandas_df, modin_df)
 
 
 class TestGroupby:
@@ -133,31 +148,3 @@ class TestMerge:
             return df1.merge(df2, on=on, how=how)
 
         run_and_compare(merge, data=self.data, data2=self.data2, on=on, how=how)
-
-
-test_data = {
-    "a": [1, 11, 101],
-    "b": [2.3, 12.1, 102.3],
-    "c": ["str1", "oas", "steqwe"],
-}
-
-
-def test_concat_with_same_df():
-    data = [[1, 11, 101], [1, 21, 201], [2, 12, 102], [2, 22, 202], [2, 32, 302]]
-    cols = ["a", "b", "c"]
-    pandas_df = pd.DataFrame(data, columns=cols)
-    modin_df = pd.DataFrame(data, columns=cols)
-    pandas_df["d"] = pandas_df["a"]
-    modin_df["d"] = modin_df["a"]
-    df_equals(pandas_df, modin_df)
-
-
-def test_drop():
-    data = [[1, 11, 101], [1, 21, 201], [2, 12, 102], [2, 22, 202], [2, 32, 302]]
-    cols = ["a", "b", "c"]
-    pandas_df = pd.DataFrame(data, columns=cols)
-    modin_df = pd.DataFrame(data, columns=cols)
-
-    pandas_df = pandas_df.drop(columns="a")
-    modin_df = modin_df.drop(columns="a")
-    df_equals(pandas_df, modin_df)


### PR DESCRIPTION
test case

``` python
import modin.pandas as mpd

a = mpd.DataFrame([[1, 11, 101], [1, 21, 201], [2, 12, 102], [2, 22, 202], [2, 32, 302]], columns=['a', 'b', 'c'])

a['d'] = a['a']

print(a)
```