### PR TITLE
Ienkovich/fold projections

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/calcite_builder.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/calcite_builder.py
@@ -182,26 +182,9 @@ class CalciteBuilder:
         frame = op.input[0]
 
         # select rows by rowid
-        if op.row_numeric_idx is not None:
-            rowid_col = self._ref(frame, "__rowid__")
-            condition = build_row_idx_filter_expr(op.row_numeric_idx, rowid_col)
-            self._push(CalciteFilterNode(condition))
-
-        # make projection
-        fields = []
-        if frame._index_cols is not None:
-            fields += frame._index_cols
-
-        if op.col_indices is not None or op.col_numeric_idx is not None:
-            if op.col_indices is not None:
-                fields += list(op.col_indices)
-            elif op.col_numeric_idx is not None:
-                fields += frame.columns[op.col_numeric_idx].tolist()
-        else:
-            fields += list(frame.columns)
-        exprs = [self._ref(frame, col) for col in fields]
-
-        self._push(CalciteProjectionNode(fields, exprs))
+        rowid_col = self._ref(frame, "__rowid__")
+        condition = build_row_idx_filter_expr(op.row_numeric_idx, rowid_col)
+        self._push(CalciteFilterNode(condition))
 
     def _process_groupby(self, op):
         frame = op.input[0]

--- a/modin/experimental/engines/omnisci_on_ray/frame/calcite_builder.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/calcite_builder.py
@@ -252,16 +252,8 @@ class CalciteBuilder:
         return AggregateExpr(self.simple_aggregates[agg], arg, res_type, False)
 
     def _process_transform(self, op):
-        frame = op.input[0]
-        fields = []
-        exprs = []
-        if op.keep_index and frame._index_cols is not None:
-            fields += frame._index_cols
-            exprs += [self._ref(frame, col) for col in frame._index_cols]
-
-        fields += op.exprs.keys()
-        exprs += self._translate(op.exprs.values())
-
+        fields = list(op.exprs.keys())
+        exprs = self._translate(op.exprs.values())
         self._push(CalciteProjectionNode(fields, exprs))
 
     def _process_join(self, op):

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -469,13 +469,13 @@ class OmnisciOnRayFrame(BasePandasFrame):
         for col in self.columns:
             exprs[col] = self.ref(col)
         for frame in other_modin_frames:
-            new_columns.extend(frame.columns.tolist())
             for col in frame.columns:
                 if col == "" or col in exprs:
                     new_col = f"__col{len(exprs)}__"
                 else:
                     new_col = col
                 exprs[new_col] = frame.ref(col)
+                new_columns.append(new_col)
 
         exprs = translate_exprs_to_base(exprs, base)
         new_columns = Index.__new__(Index, data=new_columns, dtype=self.columns.dtype)
@@ -514,10 +514,6 @@ class OmnisciOnRayFrame(BasePandasFrame):
                 index_cols=self._index_cols,
             )
         elif isinstance(other, type(self)):
-            print(self)
-            print(self._dtypes)
-            print(other)
-            print(other._dtypes)
             # For now we only support binary operations on
             # projections of the same frame, because we have
             # no support for outer join.

--- a/modin/experimental/engines/omnisci_on_ray/frame/df_algebra.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/df_algebra.py
@@ -163,6 +163,12 @@ class TransformNode(DFAlgNode):
     def __init__(self, base, exprs):
         self.exprs = exprs
         self.input = [base]
+        self._fold()
+
+    def _fold(self):
+        if isinstance(self.input[0]._op, TransformNode):
+            self.input[0] = self.input[0]._op.input[0]
+            self.exprs = translate_exprs_to_base(self.exprs, self.input[0])
 
     def copy(self):
         return TransformNode(self.input[0], self.exprs, self.keep_index)

--- a/modin/experimental/engines/omnisci_on_ray/frame/expr.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/expr.py
@@ -31,35 +31,6 @@ def _agg_dtype(agg, dtype):
         raise NotImplementedError(f"unsupported aggreagte {agg}")
 
 
-class DirectMapper:
-    def __init__(self, frame):
-        self._modin_frame = frame
-
-    def translate(self, col):
-        return self._modin_frame.ref(col)
-
-
-class TransformMapper:
-    def __init__(self, exprs):
-        self._exprs = exprs
-
-    def translate(self, col):
-        return self._exprs[col]
-
-
-class InputMapper:
-    def __init__(self):
-        self._mappers = {}
-
-    def add_mapper(self, frame, mapper):
-        self._mappers[frame] = mapper
-
-    def translate(self, ref):
-        if ref.modin_frame in self._mappers:
-            return self._mappers[ref.modin_frame].translate(ref.column)
-        return ref
-
-
 class BaseExpr(abc.ABC):
     binary_operations = {"add": "+", "sub": "-"}
 


### PR DESCRIPTION
Few changes to simplify projections processing
 - TransformNode now always has all columns in exprs explicitly, so no more keep_index flag
 - MaskNode is now used for row filters only, so now all projections are TransformNode

The only case for folding then is TransformNode over another TransformNode, which is now handled on TransformNode creation.