### PR TITLE
Izamyati/groupby.size()/count()

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -88,12 +88,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         )
 
     def groupby_size(
-        query_compiler,
-        by,
-        axis,
-        groupby_args,
-        map_args,
-        **kwargs,
+        query_compiler, by, axis, groupby_args, map_args, **kwargs,
     ):
         """Perform a groupby size.
 
@@ -148,6 +143,38 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         """
         new_frame = query_compiler._modin_frame.groupby_agg(
             by, axis, "sum", groupby_args, **kwargs
+        )
+        new_qc = query_compiler.__constructor__(new_frame)
+        if groupby_args["squeeze"]:
+            new_qc = new_qc.squeeze()
+        return new_qc
+
+    def groupby_count(query_compiler, by, axis, groupby_args, map_args, **kwargs):
+        """Perform a groupby count.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        QueryCompiler
+        """
+        new_frame = query_compiler._modin_frame.groupby_agg(
+            by, axis, "count", groupby_args, **kwargs
         )
         new_qc = query_compiler.__constructor__(new_frame)
         if groupby_args["squeeze"]:
@@ -424,7 +451,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     groupby_agg = DFAlgNotSupported("groupby_agg")
     groupby_all = DFAlgNotSupported("groupby_all")
     groupby_any = DFAlgNotSupported("groupby_any")
-    groupby_count = DFAlgNotSupported("groupby_count")
     groupby_max = DFAlgNotSupported("groupby_max")
     groupby_min = DFAlgNotSupported("groupby_min")
     groupby_prod = DFAlgNotSupported("groupby_prod")
@@ -463,7 +489,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     rtruediv = DFAlgNotSupported("rtruediv")
     skew = DFAlgNotSupported("skew")
     series_update = DFAlgNotSupported("series_update")
-    series_view = DFAlgNotSupported("series_view")    
+    series_view = DFAlgNotSupported("series_view")
     sort_index = DFAlgNotSupported("sort_index")
     std = DFAlgNotSupported("std")
     sum = DFAlgNotSupported("sum")

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -87,6 +87,45 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             self._modin_frame.mask(row_numeric_idx=index, col_numeric_idx=columns)
         )
 
+    def groupby_size(
+        query_compiler,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        **kwargs,
+    ):
+        """Perform a groupby size.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        new_frame = query_compiler._modin_frame.groupby_agg(
+            by, axis, "size", groupby_args, **kwargs
+        )
+        new_qc = query_compiler.__constructor__(new_frame)
+        if groupby_args["squeeze"]:
+            new_qc = new_qc.squeeze()
+        return new_qc
+
     def groupby_sum(query_compiler, by, axis, groupby_args, map_args, **kwargs):
         """Groupby with sum aggregation.
 
@@ -104,8 +143,8 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
         Returns
         -------
-        PandasQueryCompiler
-            A new PandasQueryCompiler
+        QueryCompiler
+            A new QueryCompiler
         """
         new_frame = query_compiler._modin_frame.groupby_agg(
             by, axis, "sum", groupby_args, **kwargs

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -455,7 +455,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     groupby_min = DFAlgNotSupported("groupby_min")
     groupby_prod = DFAlgNotSupported("groupby_prod")
     groupby_reduce = DFAlgNotSupported("groupby_reduce")
-    groupby_size = DFAlgNotSupported("groupby_size")
     head = DFAlgNotSupported("head")
     idxmax = DFAlgNotSupported("idxmax")
     idxmin = DFAlgNotSupported("idxmin")

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -197,10 +197,15 @@ class TestGroupby:
     #       res = df.groupby("cab_type").size() - this should be tested later as well
     def test_taxi_q1(self):
         df = pd.DataFrame(self.taxi_data)
-        ref = df.groupby("a").size()
+        #TODO: For now we can't do such groupby by first column since modin use that 
+        #      column as aggregation one by default. We don't support such cases at
+        #      at the moment, this will be handled later
+        #ref = df.groupby("a").size()
+        ref = df.groupby("b").size()
 
         modin_df = mpd.DataFrame(self.taxi_data)
-        modin_df = modin_df.groupby("a").size()
+        #modin_df = modin_df.groupby("a").size()
+        modin_df = modin_df.groupby("b").size()
 
         exp = to_pandas(modin_df)
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -197,14 +197,14 @@ class TestGroupby:
     #       res = df.groupby("cab_type").size() - this should be tested later as well
     def test_taxi_q1(self):
         df = pd.DataFrame(self.taxi_data)
-        #TODO: For now we can't do such groupby by first column since modin use that 
+        # TODO: For now we can't do such groupby by first column since modin use that
         #      column as aggregation one by default. We don't support such cases at
         #      at the moment, this will be handled later
-        #ref = df.groupby("a").size()
+        # ref = df.groupby("a").size()
         ref = df.groupby("b").size()
 
         modin_df = mpd.DataFrame(self.taxi_data)
-        #modin_df = modin_df.groupby("a").size()
+        # modin_df = modin_df.groupby("a").size()
         modin_df = modin_df.groupby("b").size()
 
         exp = to_pandas(modin_df)

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -146,6 +146,14 @@ class TestGroupby:
 
     @pytest.mark.parametrize("cols", cols_value)
     @pytest.mark.parametrize("as_index", bool_arg_values)
+    def test_groupby_count(self, cols, as_index):
+        def groupby_count(df, cols, as_index, **kwargs):
+            return df.groupby(cols, as_index=as_index).count()
+
+        run_and_compare(groupby_count, data=self.data, cols=cols, as_index=as_index)
+
+    @pytest.mark.parametrize("cols", cols_value)
+    @pytest.mark.parametrize("as_index", bool_arg_values)
     def test_groupby_proj_sum(self, cols, as_index):
         def groupby_sum(df, cols, as_index, **kwargs):
             return df.groupby(cols, as_index=as_index).c.sum()
@@ -172,7 +180,7 @@ class TestGroupby:
 
         exp = to_pandas(modin_df)
 
-        df_equals(ref, exp)        
+        df_equals(ref, exp)
 
     taxi_data = {
         "a": [1, 1, 2, 2],

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -222,17 +222,6 @@ class TestGroupby:
 
         df_equals(ref, exp)
 
-    def test_dt_year(self):
-        df = pd.DataFrame(self.taxi_data)
-        ref = df["c"].dt.year
-
-        modin_df = mpd.DataFrame(self.taxi_data)
-        modin_df = modin_df["c"].dt.year
-
-        exp = to_pandas(modin_df)
-
-        df_equals(ref, exp)
-
     @pytest.mark.parametrize("as_index", bool_arg_values)
     def test_taxi_q3(self, as_index):
         df = pd.DataFrame(self.taxi_data)
@@ -240,11 +229,12 @@ class TestGroupby:
 
         modin_df = mpd.DataFrame(self.taxi_data)
         modin_df = modin_df.groupby(
-            ["b", modin_df["c"].dt.year], as_index=as_index).size()
+            ["b", modin_df["c"].dt.year], as_index=as_index
+        ).size()
 
         exp = to_pandas(modin_df)
 
-        df_equals(ref, exp)            
+        df_equals(ref, exp)
 
     def test_groupby_expr_col(self):
         def groupby(df, **kwargs):


### PR DESCRIPTION
Adds groupby.count() and groupby.size(). At the moment cases like df.groupby("a").size() where "a" is the first column in dataframe or df.groupby("a").agg({"a": "size"}) don't work, this will be handled separately