### PR TITLE
fix columns order for join

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -349,15 +349,14 @@ class OmnisciOnRayFrame(BasePandasFrame):
                 col in self.columns and col in other.columns
             ), "Only cases when both frames contain key column are supported"
 
-        new_columns = on.copy()
-        new_dtypes = self._dtypes[on].tolist()
+        new_columns = []
+        new_dtypes = []
 
-        conflicting_list = list(set(self.columns) & set(other.columns))
+        conflicting_list = set(self.columns) & set(other.columns) - set(on)
         for c in self.columns:
-            if c not in on:
-                suffix = suffixes[0] if c in conflicting_list else ""
-                new_columns.append(c + suffix)
-                new_dtypes.append(self._dtypes[c])
+            suffix = suffixes[0] if c in conflicting_list else ""
+            new_columns.append(c + suffix)
+            new_dtypes.append(self._dtypes[c])
         for c in other.columns:
             if c not in on:
                 suffix = suffixes[1] if c in conflicting_list else ""

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -352,14 +352,14 @@ class OmnisciOnRayFrame(BasePandasFrame):
         new_columns = []
         new_dtypes = []
 
-        conflicting_list = set(self.columns) & set(other.columns) - set(on)
+        conflicting_cols = set(self.columns) & set(other.columns) - set(on)
         for c in self.columns:
-            suffix = suffixes[0] if c in conflicting_list else ""
+            suffix = suffixes[0] if c in conflicting_cols else ""
             new_columns.append(c + suffix)
             new_dtypes.append(self._dtypes[c])
         for c in other.columns:
             if c not in on:
-                suffix = suffixes[1] if c in conflicting_list else ""
+                suffix = suffixes[1] if c in conflicting_cols else ""
                 new_columns.append(c + suffix)
                 new_dtypes.append(other._dtypes[c])
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -617,6 +617,21 @@ class TestMerge:
 
         df_equals(ref, exp)
 
+    dt_data1 = {
+        "id": [1, 2],
+        "timestamp": pd.to_datetime(["20000101", "20000201"], format="%Y%m%d"),
+    }
+    dt_data2 = {"id": [1, 2], "timestamp_year": [2000, 2000]}
+
+    def test_merge_dt(self):
+        def merge(df1, df2, **kwargs):
+            df1["timestamp_year"] = df1["timestamp"].dt.year
+            res = df1.merge(df2, how="left", on=["id", "timestamp_year"])
+            res["timestamp_year"] = res["timestamp_year"].fillna(np.int64(-1))
+            return res
+
+        run_and_compare(merge, data=self.dt_data1, data2=self.dt_data2)
+
 
 class TestBinaryOp:
     data = {


### PR DESCRIPTION
This fixes inconsistency between column order we make in frame and calcite builder for join