### PR TITLE
fix/suppress flake8 errors

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/partition_manager.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/partition_manager.py
@@ -51,10 +51,6 @@ class OmnisciOnRayFrameManager(RayFrameManager):
         # For now OmniSci engine support only a single node cluster.
         # Therefore remote execution is not necessary and will be added
         # later.
-
-        print("Executing DF plan:")
-        plan.dump(">")
-
         omniSession = OmnisciServer()
 
         # First step is to make sure all partitions are in OmniSci.
@@ -81,19 +77,6 @@ class OmnisciOnRayFrameManager(RayFrameManager):
         rb = curs.getArrowRecordBatch()
         assert rb
         at = pyarrow.Table.from_batches([rb])
-
-        # Currently boolean columns are loaded as integer
-        # series for some reason. Fix it here for now.
-        # Using Arrow should solve the problem later.
-        # for col in dtypes.index:
-        #    if dtypes[col] == "bool":
-        #        df[col] = df[col].astype("bool")
-        #    elif dtypes[col].name == "category":
-        #        df[col] = df[col].astype("category")
-
-        # if index_cols is not None:
-        #    df = df.set_index(index_cols)
-        #    df.index.rename(cls._names_from_index_cols(index_cols), inplace=True)
 
         res = np.empty((1, 1), dtype=np.dtype(object))
         res[0][0] = cls._partition_class.put_arrow(at)

--- a/modin/experimental/engines/omnisci_on_ray/io.py
+++ b/modin/experimental/engines/omnisci_on_ray/io.py
@@ -182,7 +182,7 @@ class OmnisciOnRayIO(RayIO):
             )
 
             return cls.from_arrow(at)
-        except:
+        except pa.ArrowNotImplementedError:
             if eng in ["arrow"]:
                 raise
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -108,6 +108,8 @@ class TestCSV:
         ):
             rp = pd.read_csv(csv_file, **kwargs)
             rm = to_pandas(mpd.read_csv(csv_file, engine="arrow", **kwargs))
+            assert rp is not None
+            assert rm is not None
             # TODO: df_equals(rp, rm)  #  needs inexact comparison
 
     def test_time_parsing(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ per-file-ignores =
     stress_tests/kaggle/*:E402
     modin/experimental/pandas/__init__.py:E402
     modin/_version.py:T001
+    modin/experimental/engines/omnisci_on_ray/frame/df_algebra.py:T001
+    modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py:E402
+    modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py:E402
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Suppress "T001 print found" and "E402 module level import not at top of file"
Fix "F841 local variable is assigned to but never used", "T001 print found", "E722 do not use bare 'except'"